### PR TITLE
Zenhub #928 (JP) -- Sys Admin > Auditing - updates to improve accuracy and usability

### DIFF
--- a/app/Models/Audit.php
+++ b/app/Models/Audit.php
@@ -23,6 +23,11 @@ class Audit extends Model
         return $this->hasOne(User::class, 'id', 'user_id' );
     }
 
+    public function original_user() 
+    {
+        return $this->hasOne(User::class, 'id', 'original_auth_id');
+    }
+
     public function goal()
     {
         return $this->hasOne(Goal::class, 'id', 'auditable_id' );

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -264,5 +264,13 @@ class Conversation extends Model implements Auditable
         return $this->belongsTo(User::class, 'supervisor_signoff_id');
     }
 
+    public function transformAudit(array $data): array
+    {
+
+        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        $data['original_auth_id'] =  $original_auth_id;
+
+        return $data;
+    }
 
 }

--- a/app/Models/ConversationParticipant.php
+++ b/app/Models/ConversationParticipant.php
@@ -2,10 +2,11 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Contracts\Auditable;
 use OwenIt\Auditing\Auditable as AuditableTrait;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class ConversationParticipant extends Model implements Auditable
 {
@@ -33,9 +34,13 @@ class ConversationParticipant extends Model implements Auditable
 
     public function transformAudit(array $data): array
     {
-     
+
+        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+
         $data['auditable_id'] = $this->conversation_id;
+        $data['original_auth_id'] =  $original_auth_id;
 
         return $data;
     }
+
 }

--- a/app/Models/Goal.php
+++ b/app/Models/Goal.php
@@ -3,10 +3,11 @@
 namespace App\Models;
 
 use App\Scopes\NonLibraryScope;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Database\Eloquent\Model;
+use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use OwenIt\Auditing\Auditable as AuditableTrait;
-use OwenIt\Auditing\Contracts\Auditable;
 
 class Goal extends Model implements Auditable
 {
@@ -128,5 +129,15 @@ class Goal extends Model implements Auditable
       //return $this->designation_name();
       return array_key_exists($this->is_mandatory, self::MANDATORY_STATUS_LIST) ? self::MANDATORY_STATUS_LIST[$this->is_mandatory] : '';
   }
+
+  public function transformAudit(array $data): array
+    {
+
+        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+
+        $data['original_auth_id'] =  $original_auth_id;
+
+        return $data;
+    }
 
 }

--- a/app/Models/GoalComment.php
+++ b/app/Models/GoalComment.php
@@ -38,4 +38,14 @@ class GoalComment extends Model implements Auditable
         }
         
     }
+
+    public function transformAudit(array $data): array
+    {
+
+        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+
+        $data['original_auth_id'] =  $original_auth_id;
+
+        return $data;
+    }
 }

--- a/database/migrations/2023_06_08_195215_add_original_auth_user_in_audits_table.php
+++ b/database/migrations/2023_06_08_195215_add_original_auth_user_in_audits_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddOriginalAuthUserInAuditsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('audits', function (Blueprint $table) {
+            //
+            $table->bigInteger('original_auth_id')->nullable()->after('user_id');
+
+            $table->index(['user_id', 'original_auth_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('audits', function (Blueprint $table) {
+            //
+            $table->dropIndex(['user_id', 'original_auth_id']);
+
+            $table->dropColumn('original_auth_id');
+
+        });
+    }
+}

--- a/resources/views/sysadmin/auditing/index.blade.php
+++ b/resources/views/sysadmin/auditing/index.blade.php
@@ -26,6 +26,13 @@
             </div>
 
             <div class="form-group col-md-2">
+                <label for="audit_user">
+                    Original User 
+                </label>
+                <input name="original_user" placeholder="Name, Employee ID, iDir"  class="form-control" />
+            </div>
+
+            <div class="form-group col-md-2">
                 <label for="start_time">Start Time</label>
                 <input class="form-control datetime-range-filter" type="datetime-local"  name="start_time">
             </div>
@@ -75,6 +82,13 @@
 
         <div class="form-row">
 
+            <div class="form-group col-md-1">
+                <label for="audit_user">
+                    Audit ID 
+                </label>
+                <input name="auditable_id" placeholder=""  class="form-control" />
+            </div>
+
             <div class="form-group col-md-4">
                 <label for="old_values">
                     Old Values 
@@ -92,13 +106,13 @@
                 <label for="search">
                     &nbsp;
                 </label>
-                <input type="button" id="refresh-btn" value="Refresh" class="form-control btn btn-primary" />
+                <input type="button" id="refresh-btn" value="Search" class="form-control btn btn-primary" />
             </div>
             <div class="form-group col-md-1">
                 <label for="search">
                     &nbsp;
                 </label>
-                <input type="button" id="reset-btn" value="Reset" class="form-control btn btn-secondary" />
+                <input type="button" id="reset-btn" value="Clear" class="form-control btn btn-secondary" />
             </div>
 
         </div>
@@ -114,6 +128,7 @@
 				<tr>
                     <th>Tran ID </th>
                     <th>Audit User</th>
+                    <th>Original User</th>
                     <th>Audit Time</th>
                     <th>Event Type</th>
                     <th>Audit Type</th>
@@ -221,16 +236,21 @@
             // select: true,
             'order': [[ 0, 'desc']],
             fixedHeader: true,   
-            fixedColumn: true,         
+            fixedColumn: true, 
+            "initComplete": function(settings, json) {
+                oTable.columns.adjust().draw(false);
+            },        
             ajax: {
                 url: '{!! route('sysadmin.auditing.index') !!}',
                 data: function (data) {
                     // data.term = $('#user').val();
                     data.audit_user = $("input[name='audit_user']").val();
+                    data.original_user = $("input[name='original_user']").val();
                     data.event_type = $("select[name='event_type']").val();
                     data.auditable_type = $("select[name='auditable_type']").val();
                     data.start_time = $("input[name='start_time']").val();
                     data.end_time  = $("input[name='end_time']").val();
+                    data.auditable_id = $("input[name='auditable_id']").val();
                     data.old_values  = $("input[name='old_values']").val();
                     data.new_values  = $("input[name='new_values']").val();
                 }
@@ -238,6 +258,7 @@
             columns: [
                 {data: 'id', name: 'id', className: "dt-nowrap" },
                 {data: 'audit_user.name', name: 'audit_user.name', className: "dt-nowrap" },
+                {data: 'original_user.name', name: 'original_user.name', defaultContent:'', className: "dt-nowrap" },
                 {data: 'audit_timestamp', name: 'created_at', className: "dt-nowrap" },
                 {data: 'event', name: 'event', className: "dt-nowrap" },
                 {data: 'auditable_type_name',  name: 'auditable_type_name',  className: "dt-nowrap" },
@@ -265,6 +286,13 @@
 
         });
      
+        $("div.filter input").keydown(function(event){
+            if(event.keyCode == 13) {
+                event.preventDefault();
+                oTable.ajax.reload();
+                return false;
+            }
+        });
 
         $('#refresh-btn').on('click', function() {
             // oTable.ajax.reload(null, true);
@@ -272,11 +300,14 @@
         });
 
         $('#reset-btn').on('click', function() {
+
             $("input[name='audit_user']").val('');
+            $("input[name='original_user']").val('');
             $("select[name='event_type']").val('');
             $("select[name='auditable_type']").val('');
             $("input[name='start_time']").val('');
             $("input[name='end_time']").val('');
+            $("input[name='auditable_id']").val('');
             $("input[name='old_values']").val('');
             $("input[name='new_values']").val('');
 


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/928)

As per discussion with the product team, we would like to make a number of enhancements to the audit log generated and stored in the PDP.


### 1. Audit entries should be attributed to the user that was originally authorized into the platform.
**Current Situation**

Travis Clark logs in to the platform. He goes to the My Team page, clicks on an employee's profile, and makes a comment on an employees goal or signs off on a conversation. Those actions will be attributed to the other employee, even though it was Travis who did them. The front end accurately reflects that it was Travis (the comment shows up with his name and the sign-off shows up correctly) but the audit log shows these as actions of the employee since Travis was viewing that employee's profile when he did them.

**Desired Solution**

We rely on the original authorization to accurately track the actions of the user. Even if that user views another profile.

### 2. The audit table should be easier to search and understand
If possible, please:
- Add audit ID search function
- Use Employee ID instead of User ID in the table and results (admins have no idea of who User IDs belong to)



