### PR TITLE
Zenhub #928 (JP) -- Sys Admin > Auditing - updates to improve accuracy and usability (2rd SysAdmin's switch identity)

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -266,8 +266,13 @@ class Conversation extends Model implements Auditable
 
     public function transformAudit(array $data): array
     {
+ 
+        if(session()->has('user_is_switched')) {
+            $original_auth_id = session()->get('existing_user_id');
+        } else {
+            $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        }
 
-        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
         $data['original_auth_id'] =  $original_auth_id;
 
         return $data;

--- a/app/Models/ConversationParticipant.php
+++ b/app/Models/ConversationParticipant.php
@@ -35,7 +35,11 @@ class ConversationParticipant extends Model implements Auditable
     public function transformAudit(array $data): array
     {
 
-        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        if(session()->has('user_is_switched')) {
+            $original_auth_id = session()->get('existing_user_id');
+        } else {
+            $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        }
 
         $data['auditable_id'] = $this->conversation_id;
         $data['original_auth_id'] =  $original_auth_id;

--- a/app/Models/Goal.php
+++ b/app/Models/Goal.php
@@ -133,7 +133,11 @@ class Goal extends Model implements Auditable
   public function transformAudit(array $data): array
     {
 
-        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        if(session()->has('user_is_switched')) {
+          $original_auth_id = session()->get('existing_user_id');
+        } else {
+          $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        }
 
         $data['original_auth_id'] =  $original_auth_id;
 

--- a/app/Models/GoalComment.php
+++ b/app/Models/GoalComment.php
@@ -42,7 +42,11 @@ class GoalComment extends Model implements Auditable
     public function transformAudit(array $data): array
     {
 
-        $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        if(session()->has('user_is_switched')) {
+            $original_auth_id = session()->get('existing_user_id');
+        } else {
+            $original_auth_id = session()->has('original-auth-id') ? session()->get('original-auth-id') : Auth::id();
+        }
 
         $data['original_auth_id'] =  $original_auth_id;
 

--- a/resources/views/sysadmin/auditing/index.blade.php
+++ b/resources/views/sysadmin/auditing/index.blade.php
@@ -19,17 +19,17 @@
 
         <div class="form-row">
             <div class="form-group col-md-2">
-                <label for="audit_user">
-                    Audit User 
+                <label for="original_user">
+                    User 
                 </label>
-                <input name="audit_user" placeholder="Name, Employee ID, iDir"  class="form-control" />
+                <input name="original_user" placeholder="Name, Employee ID, iDir"  class="form-control" />
             </div>
 
             <div class="form-group col-md-2">
                 <label for="audit_user">
-                    Original User 
+                    Profile
                 </label>
-                <input name="original_user" placeholder="Name, Employee ID, iDir"  class="form-control" />
+                <input name="audit_user" placeholder="Name, Employee ID, iDir"  class="form-control" />
             </div>
 
             <div class="form-group col-md-2">


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/928)


Additional changes: sysadmin's switch identity need to update the profile user id

