### PR TITLE
#995 Supervisors does not receive conversation due emails notifications

### DIFF
--- a/app/Console/Commands/NotifyConversationDue.php
+++ b/app/Console/Commands/NotifyConversationDue.php
@@ -163,7 +163,7 @@ class NotifyConversationDue extends Command
                                         ->first();
 
                     if (!$log) {
-                        $this->logInfo( $now->format('Y-m-d') . ' - A - ' . $user->id . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
+                        $this->logInfo( $now->format('Y-m-d') . ' - A - ' . $user->id . ' (' . $user->employee_id . ')' . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
                         $sent_count += 1;
 
 
@@ -258,13 +258,15 @@ class NotifyConversationDue extends Command
                 // $row_count += 1;
 
                 // Look for direct report manager and Shared with
-                $manager_ids = SharedProfile::where('shared_id', $user->id)
-                                    ->where('shared_item', 'like',  '%"2"%' ) 
-                                    ->orderBy('id')
-                                    ->pluck('shared_with');
-                if ($user->reporting_to) {        
-                    $manager_ids->push($user->reporting_to);
-                }
+                // $manager_ids = SharedProfile::where('shared_id', $user->id)
+                //                     ->where('shared_item', 'like',  '%"2"%' ) 
+                //                     ->orderBy('id')
+                //                     ->pluck('shared_with');
+                // if ($user->reporting_to) {        
+                //     $manager_ids->push($user->reporting_to);
+                // }
+
+                $manager_ids = $this->getSupervisorList($user); 
 
                 // if no manager found, then next 
                 if ($manager_ids->count() == 0) {
@@ -286,7 +288,8 @@ class NotifyConversationDue extends Command
                         ->first();
 
                     if (!$mgr) {
-                        $this->logInfo( Carbon::now()->format('Y-m-d') . ' - E - ' .  $manager_id . ' - ' . $user->id . '  ** SKIPPED ** (MANAGER PREFER NOT TO RECECIVED EMAIL OR ORG IS NOT ALLOW EMAIL)' );
+                        $this->logInfo( Carbon::now()->format('Y-m-d') . ' - E - ' .  $manager_id . ' (' . ($mgr ? $mgr->employee_id : '      ') . ') - '  .
+                                $user->id . ' (' . $user->employee_id . ')' . '  ** SKIPPED ** (MANAGER PREFER NOT TO RECECIVED EMAIL OR ORG IS NOT ALLOW EMAIL)' );
                         $skip_count += 1;
                         continue;
                     }
@@ -333,7 +336,8 @@ class NotifyConversationDue extends Command
                                             ->first();
 
                         if (!$log) {
-                            $this->logInfo( $now->format('Y-m-d') . ' - A - ' .  $manager_id . ' - ' . $user->id . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
+                            $this->logInfo( $now->format('Y-m-d') . ' - A - ' .  $manager_id . ' (' . ($mgr ? $mgr->employee_id : '      ') . ') - '  .
+                                $user->id . ' (' . $user->employee_id . ')' . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
                             $sent_count += 1;
         
                             // Use Class to create DashboardNotification
@@ -494,7 +498,7 @@ class NotifyConversationDue extends Command
 
                     // Send Email for team members
                     if (!$log) {
-                        $this->logInfo( $now->format('Y-m-d') . ' - E - ' . $user->id . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
+                        $this->logInfo( $now->format('Y-m-d') . ' - E - ' . $user->id . ' (' . $user->employee_id . ')' .' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
                         $sent_count += 1;
 
                         $sendMail = new \App\MicrosoftGraph\SendMail();
@@ -569,13 +573,15 @@ class NotifyConversationDue extends Command
                 // $row_count += 1;
 
                 // Look for direct report manager and Shared with
-                $manager_ids = SharedProfile::where('shared_id', $user->id)
-                                    ->where('shared_item', 'like',  '%"2"%' ) 
-                                    ->orderBy('id')
-                                    ->pluck('shared_with');
-                if ($user->reporting_to) {        
-                    $manager_ids->push($user->reporting_to);
-                }
+                // $manager_ids = SharedProfile::where('shared_id', $user->id)
+                //                     ->where('shared_item', 'like',  '%"2"%' ) 
+                //                     ->orderBy('id')
+                //                     ->pluck('shared_with');
+                // if ($user->reporting_to) {        
+                //     $manager_ids->push($user->reporting_to);
+                // }
+
+                $manager_ids = $this->getSupervisorList($user); 
 
                 // if no manager found, then next 
                 if ($manager_ids->count() == 0) {
@@ -597,7 +603,8 @@ class NotifyConversationDue extends Command
                         ->first();
 
                     if (!$mgr) {
-                        $this->logInfo( Carbon::now()->format('Y-m-d') . ' - E - ' .  $manager_id . ' - ' . $user->id . '  ** SKIPPED ** (MANAGER PREFER NOT TO RECECIVED EMAIL OR ORG IS NOT ALLOW EMAIL)' );
+                        $this->logInfo( Carbon::now()->format('Y-m-d') . ' - E - ' .  $manager_id . ' (' . ($mgr ? $mgr->employee_id : '      ') . ') - '  .
+                        $user->id . ' (' . $user->employee_id . ')' . ' - ' . '  ** SKIPPED ** (MANAGER PREFER NOT TO RECECIVED EMAIL OR ORG IS NOT ALLOW EMAIL)' );
                         $skip_count += 1;
                         continue;
                     }
@@ -672,7 +679,8 @@ class NotifyConversationDue extends Command
 
                         // Send Email for team members
                         if (!$log) {
-                            $this->logInfo( $now->format('Y-m-d') . ' - E - ' .  $manager_id . ' - ' . $user->id . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
+                            $this->logInfo( $now->format('Y-m-d') . ' - E - ' .  $manager_id . ' (' . ($mgr ? $mgr->employee_id : '      ') . ') - '  .
+                            $user->id . ' (' . $user->employee_id . ')' . ' - ' . $dueDate->format('Y-m-d') . ' - (' . $dayDiff . ') - ' . $dueIndays);
                             $sent_count += 1;
 
                             $sendMail = new \App\MicrosoftGraph\SendMail();
@@ -716,6 +724,45 @@ class NotifyConversationDue extends Command
         $this->logInfo("Total eligible managers         : " . $row_count );
         $this->logInfo("Total notification skipped      : " . $skip_count );
         $this->logInfo("Total notification created/Sent : " . $sent_count );
+
+    }
+
+    protected function getSupervisorList ($current_user) {
+
+        // Shared Profile
+        $manager_ids = SharedProfile::where('shared_id', $current_user->id)
+                        ->join('users','users.id','shared_profiles.shared_with')
+                        ->join('employee_demo','employee_demo.employee_id', 'users.employee_id')
+                        ->whereNull('employee_demo.date_deleted')
+                        ->where('shared_item', 'like',  '%"2"%' ) 
+                        ->orderBy('users.id')
+                        ->pluck('shared_with');
+
+        // Superviser
+        $supervisorList = $current_user->supervisorList();
+        $supervisorListCount = $current_user->supervisorListCount();
+        $preferredSupervisor = $current_user->preferredSupervisor();
+
+        if ($supervisorListCount <= 1) {
+            if ($current_user->reportingManager) {
+                $manager_ids->push( $current_user->reportingManager->id );
+            }
+        } else {
+            if (!$preferredSupervisor) {
+                if ($current_user->reportingManager) {
+                    $manager_ids->push( $current_user->reportingManager->id );
+                }
+            } else {
+                foreach ($supervisorList as $supv) {
+                    if ($supv->employee_id == $preferredSupervisor->supv_empl_id) {
+                        $manager_ids->push( $supv->id );
+                        break;
+                    }
+                }
+            }
+        }
+
+        return $manager_ids;
 
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -295,7 +295,7 @@ class User extends Authenticatable
         ->join('employee_demo AS e', 'p.reports_to', 'e.position_number')
         ->join('users AS v', 'e.employee_id', 'v.employee_id')
         ->distinct()
-        ->select('e.position_number', 'v.employee_id', 'v.name')
+        ->select('e.position_number', 'v.employee_id', 'v.name', 'v.id')
         ->whereNull('e.date_deleted')
         ->where('employee_demo.employee_id', $this->employee_id)
         ->orderBy('e.position_number')
@@ -306,7 +306,7 @@ class User extends Authenticatable
     public function preferredSupervisor() {
         if ($this->employee_demo && $this->employee_demo->position_number) {
             return PreferredSupervisor::join('users AS u', 'u.employee_id', 'preferred_supervisor.supv_empl_id')
-            ->select('preferred_supervisor.supv_empl_id', 'u.name')
+            ->select('preferred_supervisor.supv_empl_id', 'u.name', 'u.id')
             ->where('preferred_supervisor.employee_id', '=', $this->employee_id)
             ->where('preferred_supervisor.position_nbr', '=', $this->employee_demo->position_number)
             ->first();


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/995) 

Supervisors are not receiving email notifications when users have multiple current supervisors.
Expected result: The current supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Same issue is with the Delegate supervisor
Expected result: The delegate supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Test data:
User 1: 60290 Swan,Chris L
Supervisor: 1) Current Supervisor: Wiebe,Heather - Did not receive email
2) Mikkelsen,Kye
3) Delegate supervisor: Clark, Travis- Did not receive email

User 2: 27950 Wahl,Diane M
Supervisor: 1) Current Supervisor: Gill,Randher - Did not receive email
2) Morishita,Sheri
3) Delegate supervisor: Clark, Travis- Did not receive email

User 3: 117609 Partridge,Elizabeth
Supervisor: 1) Hamel,Nicole
2) Current Supervisor: Lim,Catherine - Did not receive email
3) Sall,Nelampal
4) Ivanova,Vessela

User 4: 29879 Schultz,Beverly
Supervisor:

Current Supervisor: Reynolds,Catherine - must not receive email
Noseworthy,Deborah
Delegate - Zilke,Karen

