### PR TITLE
Zenhub #928 (JP) -- Sys Admin > Auditing - updates to improve accuracy and usability

### DIFF
--- a/app/Console/Commands/NotifyConversationDue.php
+++ b/app/Console/Commands/NotifyConversationDue.php
@@ -774,7 +774,7 @@ class NotifyConversationDue extends Command
 
         // write to log
         $this->task->details = $this->details;
-        $this->task->save();
+        // $this->task->save();
 
     }
 


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/995)

Supervisors are not receiving email notifications when users have multiple current supervisors.
Expected result: The current supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Same issue is with the Delegate supervisor
Expected result: The delegate supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Test data:
User 1: 60290 Swan,Chris L
Supervisor: 1) Current Supervisor: Wiebe,Heather - Did not receive email
2) Mikkelsen,Kye
3) Delegate supervisor: Clark, Travis- Did not receive email

User 2: 27950 Wahl,Diane M
Supervisor: 1) Current Supervisor: Gill,Randher - Did not receive email
2) Morishita,Sheri
3) Delegate supervisor: Clark, Travis- Did not receive email

User 3: 117609 Partridge,Elizabeth
Supervisor: 1) Hamel,Nicole
2) Current Supervisor: Lim,Catherine - Did not receive email
3) Sall,Nelampal
4) Ivanova,Vessela

User 4: 29879 Schultz,Beverly
Supervisor:

Current Supervisor: Reynolds,Catherine - must not receive email
Noseworthy,Deborah
Delegate - Zilke,Karen