### PR TITLE
#995 Supervisors does not receive conversation due emails notifications

### DIFF
--- a/app/Console/Commands/NotifyConversationDue.php
+++ b/app/Console/Commands/NotifyConversationDue.php
@@ -48,6 +48,14 @@ class NotifyConversationDue extends Command
      */
     public function handle()
     {
+
+        $switch = env('EMAIL_NOTIFICATION_ENABLED');
+        if (!($switch)) {
+            $this->info( now() );
+            $this->info( "This process was skipped. The EMAIL_NOTIFICATION_ENABLED (in .env) is not enabled.");
+            return 0;
+        }
+
         $start_time = Carbon::now();
 
         $this->task = JobSchedAudit::Create([

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -78,11 +78,6 @@ class Kernel extends ConsoleKernel
         ->timezone('America/Vancouver')
         ->dailyAt('02:00');
 
-        $schedule->command('command:NotifyConversationDue')
-        ->timezone('America/Vancouver')    
-        ->dailyAt('02:30')
-        ->appendOutputTo(storage_path('logs/NotifyConversationDue.log'));
-        
         $schedule->command('command:BuildEmployeeDemoTree')
         ->timezone('America/Vancouver')
         ->dailyAt('03:00');
@@ -98,6 +93,11 @@ class Kernel extends ConsoleKernel
         $schedule->command('command:MaintainLogs')
         ->timezone('America/Vancouver')    
         ->dailyAt('06:00');
+
+        $schedule->command('command:NotifyConversationDue')
+        ->timezone('America/Vancouver')    
+        ->dailyAt('06:15')
+        ->appendOutputTo(storage_path('logs/NotifyConversationDue.log'));
         
         $schedule->command('notify:daily')
         ->dailyAt('08:00')


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/995)

Supervisors are not receiving email notifications when users have multiple current supervisors.
Expected result: The current supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Same issue is with the Delegate supervisor
Expected result: The delegate supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Test data:
User 1: 60290 Swan,Chris L
Supervisor: 1) Current Supervisor: Wiebe,Heather - Did not receive email
2) Mikkelsen,Kye
3) Delegate supervisor: Clark, Travis- Did not receive email

User 2: 27950 Wahl,Diane M
Supervisor: 1) Current Supervisor: Gill,Randher - Did not receive email
2) Morishita,Sheri
3) Delegate supervisor: Clark, Travis- Did not receive email

User 3: 117609 Partridge,Elizabeth
Supervisor: 1) Hamel,Nicole
2) Current Supervisor: Lim,Catherine - Did not receive email
3) Sall,Nelampal
4) Ivanova,Vessela

User 4: 29879 Schultz,Beverly
Supervisor:

Current Supervisor: Reynolds,Catherine - must not receive email
Noseworthy,Deborah
Delegate - Zilke,Karen