### PR TITLE
#995 Supervisors does not receive conversation due emails notifications

### DIFF
--- a/app/Console/Commands/NotifyConversationDue.php
+++ b/app/Console/Commands/NotifyConversationDue.php
@@ -607,6 +607,7 @@ class NotifyConversationDue extends Command
                         ->where('access_organizations.allow_email_msg', 'Y')
                         ->whereNull('date_deleted')                                                
                         ->where('users.id',  $manager_id)
+                        ->select('users.*')
                         ->first();
 
                     if (!$mgr) {
@@ -619,10 +620,10 @@ class NotifyConversationDue extends Command
 
 
                     // User Prference 
-                    $pref = UserPreference::where('user_id', $user->manager_id)->first();
+                    $pref = UserPreference::where('user_id', $mgr->id)->first();
                     if (!$pref) {
                         $pref = new UserPreference;
-                        $pref->user_id = $user->manager_id;
+                        $pref->user_id = $mgr->id;
                     }
 
                     // $due = Conversation::nextConversationDue( $user );
@@ -668,12 +669,11 @@ class NotifyConversationDue extends Command
                     }
 
                     // To avoid the past email sent out when the sysadmin turn on global flag under system access control
-                    if ( ($dayDiff < 0 && $dueDate < today()->subDays(6)) ||
-                         ($dayDiff >= 0 && $dueDate < today()) ) {
-                        $bSend = false;                        
+                    if ($bSend && ($dueDate < today()->subDays(6)))  {
+                            $bSend = false;                        
                     }                      
-            
-                    if ($bSend) {
+
+                     if ($bSend) {
 
                         // check the notification sent or not 
                         $log = NotificationLog::where('alert_type', 'N')

--- a/app/Http/Controllers/SysAdmin/NotificationController.php
+++ b/app/Http/Controllers/SysAdmin/NotificationController.php
@@ -56,12 +56,14 @@ class NotificationController extends Controller
                 })
                 ->when($request->notify_user, function ($query) use($request) {
                     $query->whereHas('notify_user', function ($query) use($request) { 
-                        $query->whereRaw("lower(name) like  '%". strtolower($request->notify_user) . "%'"); 
+                        $query->whereRaw("lower(name) like  '%". strtolower($request->notify_user) . "%'") 
+                              ->orwhereRaw("users.employee_id like '%". strtolower($request->notify_user) . "%'"); 
                     });   
                 })
                 ->when($request->overdue_user, function ($query) use($request) {
                     $query->whereHas('overdue_user', function ($query) use($request) { 
-                        $query->whereRaw("lower(name) like  '%". strtolower($request->overdue_user) . "%'"); 
+                        $query->whereRaw("lower(name) like  '%". strtolower($request->overdue_user) . "%'") 
+                              ->orwhereRaw("users.employee_id like '%". strtolower($request->overdue_user) . "%'"); 
                     });   
                 })
                 ->when($request->notify_due_date, function ($query) use($request) {


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/995)

Supervisors are not receiving email notifications when users have multiple current supervisors.
Expected result: The current supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Same issue is with the Delegate supervisor
Expected result: The delegate supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Test data:
User 1: 60290 Swan,Chris L
Supervisor: 1) Current Supervisor: Wiebe,Heather - Did not receive email
2) Mikkelsen,Kye
3) Delegate supervisor: Clark, Travis- Did not receive email

User 2: 27950 Wahl,Diane M
Supervisor: 1) Current Supervisor: Gill,Randher - Did not receive email
2) Morishita,Sheri
3) Delegate supervisor: Clark, Travis- Did not receive email

User 3: 117609 Partridge,Elizabeth
Supervisor: 1) Hamel,Nicole
2) Current Supervisor: Lim,Catherine - Did not receive email
3) Sall,Nelampal
4) Ivanova,Vessela

User 4: 29879 Schultz,Beverly
Supervisor:

Current Supervisor: Reynolds,Catherine - must not receive email
Noseworthy,Deborah
Delegate - Zilke,Karen