### PR TITLE
#995 Supervisors does not receive conversation due emails notifications

### DIFF
--- a/app/Console/Commands/NotifyConversationDue.php
+++ b/app/Console/Commands/NotifyConversationDue.php
@@ -746,7 +746,6 @@ class NotifyConversationDue extends Command
                         ->pluck('shared_with');
 
         // Superviser
-        $supervisorList = $current_user->supervisorList();
         $supervisorListCount = $current_user->supervisorListCount();
         $preferredSupervisor = $current_user->preferredSupervisor();
 
@@ -760,12 +759,7 @@ class NotifyConversationDue extends Command
                     $manager_ids->push( $current_user->reportingManager->id );
                 }
             } else {
-                foreach ($supervisorList as $supv) {
-                    if ($supv->employee_id == $preferredSupervisor->supv_empl_id) {
-                        $manager_ids->push( $supv->id );
-                        break;
-                    }
-                }
+                $manager_ids->push( $preferredSupervisor->id );
             }
         }
 


### PR DESCRIPTION
[Ticket](https://app.zenhub.com/workspaces/performance-development-60020b0a13a09c0014af2469/issues/gh/bcgov/performance/995)

Supervisors are not receiving email notifications when users have multiple current supervisors.
Expected result: The current supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Same issue is with the Delegate supervisor
Expected result: The delegate supervisor selected must receive both the email and in-app notifications
Actual: Only in-app notifications are received

Test data:
User 1: 60290 Swan,Chris L
Supervisor: 1) Current Supervisor: Wiebe,Heather - Did not receive email
2) Mikkelsen,Kye
3) Delegate supervisor: Clark, Travis- Did not receive email

User 2: 27950 Wahl,Diane M
Supervisor: 1) Current Supervisor: Gill,Randher - Did not receive email
2) Morishita,Sheri
3) Delegate supervisor: Clark, Travis- Did not receive email

User 3: 117609 Partridge,Elizabeth
Supervisor: 1) Hamel,Nicole
2) Current Supervisor: Lim,Catherine - Did not receive email
3) Sall,Nelampal
4) Ivanova,Vessela

User 4: 29879 Schultz,Beverly
Supervisor:

Current Supervisor: Reynolds,Catherine - must not receive email
Noseworthy,Deborah
Delegate - Zilke,Karen